### PR TITLE
Fixing body order (to reflect table of contents)

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -49,9 +49,16 @@ function saveOutputFileContent() {
   var header = fs.readFileSync(__dirname + '/tmpl/header.tmpl', 'utf-8');
   var footer = fs.readFileSync(__dirname + '/tmpl/footer.tmpl', 'utf-8');
 
+  // Grab the global data so we can insert it where we want (at the end)
+  var globalData = otherApiHtmlData[0];
+
+  // Remove the global data from the array so it is no displayed twice
+  otherApiHtmlData.shift();
+
   var apiContentOnlyHtml = homeHtmlData.concat(
     otherApiHtmlData,
-    classHtmlData
+    classHtmlData,
+    globalData
   ).join('\n');
 
   var singlePageApiHtml = [header].concat(

--- a/publish.js
+++ b/publish.js
@@ -56,9 +56,9 @@ function saveOutputFileContent() {
   otherApiHtmlData.shift();
 
   var apiContentOnlyHtml = homeHtmlData.concat(
-    otherApiHtmlData,
-    classHtmlData,
-    globalData
+    otherApiHtmlData, // Modules
+    classHtmlData, // Classes
+    globalData // Global
   ).join('\n');
 
   var singlePageApiHtml = [header].concat(

--- a/tmpl/container.tmpl
+++ b/tmpl/container.tmpl
@@ -54,6 +54,7 @@
     <?js } else if (doc.kind === 'class') { ?>
         <?js= self.partial('method.tmpl', doc) ?>
     <?js } else { ?>
+        <h2>Global</h2>
         <?js if (doc.description) { ?>
             <div class="description"><?js= doc.description ?></div>
         <?js } ?>


### PR DESCRIPTION
* Sorted modules in order, so when rendering them in the HTML they have the same order.
* Fixed bug that caused modules with `home` in the name to appear in the `home` part of the JSDocs causing modules to seem out of order

Closes #16